### PR TITLE
Ensure to open files in current editor window

### DIFF
--- a/src/code_file_nav.ts
+++ b/src/code_file_nav.ts
@@ -83,7 +83,7 @@ export function showFileList(dir?: string): void {
                 showFileList(file.path);
             } else if (file.isFile) {
                 vscode.workspace.openTextDocument(file.path).then(doc => {
-                    vscode.window.showTextDocument(doc);
+                    vscode.window.showTextDocument(doc, vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined);
                 });
             }
         });


### PR DESCRIPTION
By default `showTextDocument` opens files in first window from left, and that's how it's used here.
That gives bad experience if you opened navigator from other window (you expect the file to be opened in very same window at which you initialized navigator).

This patch fixes that.